### PR TITLE
Dev/context overflow fix

### DIFF
--- a/components/lib/CanvasEditor.tsx
+++ b/components/lib/CanvasEditor.tsx
@@ -40,7 +40,7 @@ export default function CanvasEditor({
         if (canvasRef.current) {
             setDrawer(new Draw(canvasRef.current, {background: ground}));
         }
-    }, [canvasRef.current]);
+    }, [canvasRef, ground]);
 
     if (canvasRef && canvasRef.current && drawer) {
         void render();

--- a/components/lib/ThreeComponent.tsx
+++ b/components/lib/ThreeComponent.tsx
@@ -8,6 +8,7 @@ import {TrackballControls} from "three/examples/jsm/controls/TrackballControls";
 import {ThreeControlType} from "@/src/types/general";
 import {Grass} from "@/src/utils/grass/grass";
 import {renderEnvironment} from "@/src/utils/background";
+import {getArrowHelper, getGroundPlane, getMeshForItem} from "@/src/utils/model";
 
 
 // TODO: Move this all to React.useMemo to preserve data over re-renders
@@ -97,48 +98,6 @@ export default function ThreeComponent({
                 controls.maxPolarAngle = Math.PI / 2;
         }
     }
-
-    const getMeshForItem = (item: AssetObject): THREE.Mesh => {
-        let model;
-        let material = new THREE.MeshBasicMaterial({ color: item.color ?
-                new THREE.Color(item.color) : 0x000000 });
-        let geometry;
-        let position1, position2;
-        switch (item.type) {
-            case "rect":
-                const rect = item as Rectangle;
-                geometry = new THREE.BoxGeometry(rect.w, rect.h, Math.round((rect.w + rect.h) / 2));
-                break;
-            case "circle":
-                geometry = new THREE.SphereGeometry((item as Circle).radius, 32, 16 );
-                break;
-            case "line":
-                const line = item as Line;
-                position1 = new THREE.Vector3(line.x1, line.y1, 0);
-                position2 = new THREE.Vector3(line.x2, line.y2, 0);
-                const height = position1.distanceTo(position2);
-
-                geometry = new THREE.CylinderGeometry( 5, 5, height, 32 );
-        }
-        model = new THREE.Mesh(geometry, material);
-        if (model && position1 && position2) {
-            const positionMid = new THREE.Vector3();
-            positionMid.addVectors(position1, position2).multiplyScalar(0.5);
-            model.position.copy(positionMid);
-            const direction = new THREE.Vector3();
-            direction.subVectors(position2, position1).normalize();
-
-            const quaternion = new THREE.Quaternion();
-            quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), direction);
-            model.setRotationFromQuaternion(quaternion);
-        } else if (model && item.type === "rect") {
-            const rect = item as Rectangle;
-            model.position.set(rect.x + rect.w / 2, rect.y + rect.h / 2, rect.z || 0);
-        } else if (model && typeof item.x === 'number' && typeof item.y === "number") {
-            model.position.set(item.x, item.y, item.z || 0);
-        }
-        return model;
-    };
 
     const refreshSceneItems = () => {
         if (scene) {
@@ -236,22 +195,7 @@ export default function ThreeComponent({
     };
 
     const addArrowHelper = ()=>{
-        const arrowGroup = new THREE.Group();
-        arrowGroup.name = "arrows";
-        const xAxisDirection = new THREE.Vector3(1, 0, 0);
-        const yAxisDirection = new THREE.Vector3(0, 1, 0);
-        const zAxisDirection = new THREE.Vector3(0, 0, 1);
-
-        const origin = new THREE.Vector3( 0, 0, 0 );
-        const length = 100;
-
-        const xAxisArrow = new THREE.ArrowHelper(xAxisDirection, origin, length, 0xff0000);
-        const yAxisArrow = new THREE.ArrowHelper(yAxisDirection, origin, length, 0x00ff00);
-        const zAxisArrow = new THREE.ArrowHelper(zAxisDirection, origin, length, 0x0000ff);
-
-        arrowGroup.add(xAxisArrow);
-        arrowGroup.add(yAxisArrow);
-        arrowGroup.add(zAxisArrow);
+        const arrowGroup = getArrowHelper();
 
         scene.add(arrowGroup);
 
@@ -368,30 +312,13 @@ export default function ThreeComponent({
 
     };
 
-    const addBasePlane = () => {
-        return new Promise(resolve => {
-            if (!scene || scene.children.find(mesh => mesh.name === "plane")) {
-                return resolve(false);
-            }
-            const geometry = new THREE.PlaneGeometry( planeSize, planeSize );
-            const material = new THREE.MeshBasicMaterial( {color: 0xffff00, side: THREE.DoubleSide} );
-            const loader = new THREE.TextureLoader();
-            loader.load(ground ,
-                function ( texture ) {
-                    texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
-                    texture.offset.set( 0, 0 );
-                    texture.repeat.set( 2, 2 );
-                    material.map = texture;
-                    material.needsUpdate = true;
-                    const plane = new THREE.Mesh( geometry, material );
-                    //plane.position.setX(planeSize / 2);
-                    //plane.position.setY(planeSize / 2);
-                    plane.position.setZ(-1);
-                    plane.name = "plane";
-                    scene.add( plane );
-                    resolve(plane);
-                });
-        });
+    const addBasePlane = async () => {
+        if (!scene || scene.children.find(mesh => mesh.name === "plane")) {
+            return false;
+        }
+        const plane = await getGroundPlane(planeSize, planeSize, ground);
+        scene.add(plane);
+        return plane;
     };
 
     const setEnvironment = () => {

--- a/components/lib/ThreeComponent.tsx
+++ b/components/lib/ThreeComponent.tsx
@@ -9,6 +9,8 @@ import {ThreeControlType} from "@/src/types/general";
 import {Grass} from "@/src/utils/grass/grass";
 import {renderEnvironment} from "@/src/utils/background";
 
+
+// TODO: Move this all to React.useMemo to preserve data over re-renders
 let camera: THREE.PerspectiveCamera,
     renderer: THREE.WebGLRenderer,
     scene: THREE.Scene, controls: OrbitControls | TrackballControls,
@@ -158,6 +160,7 @@ export default function ThreeComponent({
     const loadTHREEComponent = () => {
         console.log('Load');
 
+        // TODO: No need window check since we have them outside
         if (typeof window !== 'undefined') {
             THREE.Object3D.DEFAULT_UP.set(0, 0, -1);
 
@@ -198,6 +201,7 @@ export default function ThreeComponent({
             renderer.render(scene, camera);
             updateControls();
 
+            // TODO: Where the render should be placed if we are using Memos?
             const animate = () => {
                 if (grassEnabled && grass) {
                     grass.refresh();

--- a/components/lib/ThreeComponent.tsx
+++ b/components/lib/ThreeComponent.tsx
@@ -1,24 +1,24 @@
 "use client";
-import React, {useRef, useEffect, useState} from 'react';
+import React, {useRef, useEffect, useMemo} from 'react';
 import * as THREE from 'three';
-import {AssetObject, Circle, Line, Rectangle} from "@/src/types/assets";
+import {AssetObject, Line, Rectangle } from "@/src/types/assets";
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
-import {Mesh} from "three";
-import {TrackballControls} from "three/examples/jsm/controls/TrackballControls";
-import {ThreeControlType} from "@/src/types/general";
-import {Grass} from "@/src/utils/grass/grass";
-import {renderEnvironment} from "@/src/utils/background";
-import {getArrowHelper, getGroundPlane, getMeshForItem} from "@/src/utils/model";
+import { Mesh, Scene } from "three";
+import { TrackballControls } from "three/examples/jsm/controls/TrackballControls";
+import { ThreeControlType } from "@/src/types/general";
+import { Grass } from "@/src/utils/grass/grass";
+import { renderEnvironment } from "@/src/utils/background";
+import {
+    createShadowObject,
+    getArrowHelper,
+    getControls,
+    getGroundPlane,
+    getMeshForItem,
+    setInitialCameraPosition
+} from "@/src/utils/model";
+import { Object3D } from "three/src/core/Object3D";
 
-
-// TODO: Move this all to React.useMemo to preserve data over re-renders
-let camera: THREE.PerspectiveCamera,
-    renderer: THREE.WebGLRenderer,
-    scene: THREE.Scene, controls: OrbitControls | TrackballControls,
-    shadowObject: THREE.Mesh|null,
-    grass: Grass,
-    animationID: number|undefined,
-    context:  WebGLRenderingContext | WebGL2RenderingContext | undefined;
+let animationID: number|undefined;
 
 export default function ThreeComponent({
     items,
@@ -43,19 +43,105 @@ export default function ThreeComponent({
     grassEnabled?: boolean,
     skyEnabled?: boolean
 }) {
-    console.log('Window: ', typeof window);
-    const containerRef = useRef<HTMLDivElement>(null);
-    const [loaded, setLoaded] = useState(false);
-    let arrowHelpers: THREE.Group;
-    let helpersCount = 0;
-    const helperNames = [
-        "sky",
-        "light",
-        "hemisphereLight",
-        "grass",
-        "arrows",
-        "plane"];
-    const planeSize = Math.max(width, height, 1000)*10;
+    const containerRef = useRef<HTMLDivElement>(null),
+        planeSize = Math.max(width, height, 1000)*10,
+        helperNames = [
+            "sky",
+            "light",
+            "hemisphereLight",
+            "grass",
+            "arrows",
+            "plane",
+            "shadowObject"
+        ]
+
+    let arrowHelpers: THREE.Group,
+        helpersCount = 0;
+    const addBasePlane = async (scene: Scene) => {
+        if (!scene || scene.children.find(mesh => mesh.name === "plane")) {
+            return false;
+        }
+        const plane = await getGroundPlane(planeSize, planeSize, ground);
+        scene.add(plane);
+        return plane;
+    };
+
+
+    const initializeThreeGlobals = () => {
+        // I am using globals, to keep THREE JS references intact. useMemo and useRef did not work properly in fast-render mode
+        window.AT_Editor = window.AT_Editor || {};
+        if (window.AT_Editor.scene && window.AT_Editor.camera && window.AT_Editor.renderer) {
+            return {
+                camera:window.AT_Editor.camera,
+                renderer: window.AT_Editor.renderer,
+                scene: window.AT_Editor.scene,
+                grass: window.AT_Editor.grass
+            }
+        }
+        // Set Globals
+        THREE.Object3D.DEFAULT_UP.set(0, 0, -1);
+
+        const camera: THREE.PerspectiveCamera = new THREE.PerspectiveCamera(75, width / height, 0.1, 20001),
+            renderer: THREE.WebGLRenderer = new THREE.WebGLRenderer({
+                antialias: true
+            }),
+            context:  WebGLRenderingContext | WebGL2RenderingContext | undefined = renderer.getContext(),
+            scene: THREE.Scene = new THREE.Scene(),
+            grass: Grass|undefined = grassEnabled ? new Grass(scene,{
+                instances: 1000000,
+                width: planeSize,
+                height: planeSize
+            }) : undefined;
+
+        context.canvas.addEventListener("webglcontextlost", (e) => {
+            e.preventDefault();
+            console.warn("Context Lost, cancel rendering: ", animationID);
+            if (typeof animationID === "number") {
+                cancelAnimationFrame(animationID);
+            }
+        }, false);
+        context.canvas.addEventListener("webglcontextrestored", (e) => {
+            e.preventDefault();
+            console.warn("Context Restored");
+        }, false);
+
+        renderer.setSize(width, height);
+        camera.up.set(0, 0, 1);
+        if (grass) {
+            grass.addToScene();
+        }
+        if (skyEnabled) {
+            renderEnvironment(scene);
+        }
+        renderer.render(scene, camera);
+
+        void addBasePlane(scene);
+
+        const shadowObject = createShadowObject(reference);
+        scene.add(shadowObject);
+        window.AT_Editor.scene = scene;
+        window.AT_Editor.camera = camera;
+        window.AT_Editor.renderer = renderer;
+        window.AT_Editor.grass = grass;
+        return {camera, renderer, scene, grass}
+    }
+
+    const {
+        camera,
+        renderer,
+        scene,
+        grass
+    } = useMemo(initializeThreeGlobals, []);
+
+    const controls: TrackballControls | OrbitControls = useMemo(() => {
+        window.AT_Editor = window.AT_Editor || {};
+        window.AT_Editor.controls = window.AT_Editor.controls ||
+            getControls(threeControl, camera, renderer);
+        return window.AT_Editor.controls;
+    }, [threeControl, camera, renderer]);
+
+    const shadowObject: Mesh|null|undefined = scene.children.find((mesh: Object3D)=>
+        mesh.name === "shadowObject") as Mesh|undefined;
 
     const updateCameraPosition = () => {
         if (camera && renderer) {
@@ -86,24 +172,11 @@ export default function ThreeComponent({
         }
     };
 
-    const updateControls = () => {
-        switch (threeControl) {
-            case "trackball":
-                controls = new TrackballControls( camera, renderer.domElement );
-                break;
-            case "orbit":
-            case "object":
-            default:
-                controls = new OrbitControls( camera, renderer.domElement );
-                controls.maxPolarAngle = Math.PI / 2;
-        }
-    }
-
-    const refreshSceneItems = () => {
+    useEffect(()=> {
         if (scene) {
             scene.children
-                .filter(m=>m.name && m.name.startsWith('mesh_'))
-                .forEach((m)=>scene.remove(m));
+                .filter((m: Object3D)=>m.name && m.name.startsWith('mesh_'))
+                .forEach((m: Object3D)=>scene.remove(m));
             //scene.clear();
         }
         items.forEach((item, index) => {
@@ -114,102 +187,65 @@ export default function ThreeComponent({
                 scene.add(model);
             }
         });
-    };
+    }, [items, scene])
 
-    const loadTHREEComponent = () => {
-        console.log('Load');
 
-        // TODO: No need window check since we have them outside
-        if (typeof window !== 'undefined') {
-            THREE.Object3D.DEFAULT_UP.set(0, 0, -1);
-
-            scene = scene || new THREE.Scene();
-            camera = camera || new THREE.PerspectiveCamera(75, width / height, 0.1, 20001);
-            if (!renderer) {
-                renderer = new THREE.WebGLRenderer({
-                    antialias: true
-                });
-                context = renderer.getContext();
-
-                context.canvas.addEventListener("webglcontextlost", (e) => {
-                    e.preventDefault();
-                    console.warn("Context Lost, cancel rendering: ", animationID);
-                    if (typeof animationID === "number") {
-                        cancelAnimationFrame(animationID);
-                    }
-                }, false);
-                context.canvas.addEventListener("webglcontextrestored", (e) => {
-                    e.preventDefault();
-                    console.warn("Context Restored");
-                }, false);
-            }
-
-            renderer.setSize(width, height);
-            if (containerRef.current && containerRef.current.childNodes.length > 1) {
-                while (containerRef.current?.childNodes.length) {
-                    containerRef.current?.removeChild(containerRef.current?.childNodes[0]);
-                }
-                containerRef.current?.appendChild(renderer.domElement);
-            } else if (containerRef.current && !containerRef.current.childNodes.length) {
-                containerRef.current?.appendChild(renderer.domElement);
-            }
-
-            camera.up.set(0, 0, 1);
-            refreshSceneItems();
-
-            renderer.render(scene, camera);
-            updateControls();
-
-            // TODO: Where the render should be placed if we are using Memos?
-            const animate = () => {
-                if (grassEnabled && grass) {
-                    grass.refresh();
-                }
-                controls.update();
-                renderer.render(scene, camera);
-                animationID = requestAnimationFrame(animate);
-            };
-
-            updateCameraPosition();
-
-            if (typeof animationID === "number") {
-                console.log("Cancel old animation ", animationID);
-                cancelAnimationFrame(animationID);
-                animationID = undefined;
-            }
-            animate();
-
-            setLoaded(true);
-
-            if (process.env.NODE_ENV === "development") {
-                window.AT_Editor = window.AT_Editor || {};
-                window.AT_Editor.scene = scene;
-                window.AT_Editor.camera = camera;
-                window.AT_Editor.renderer = renderer;
-                window.AT_Editor.controls = controls;
-            }
-            void addBasePlane().then(() => setEnvironment())
-            // Clean up the event listener when the component is unmounted
-            return () => {};
+    const cancelAnimation = () => {
+        if (typeof animationID === "number") {
+            console.log("Cancel old animation ", animationID);
+            cancelAnimationFrame(animationID);
+            animationID = undefined;
         }
     };
+
+    useEffect(() => {
+        if (containerRef.current && containerRef.current.childNodes.length > 1) {
+            while (containerRef.current?.childNodes.length) {
+                containerRef.current?.removeChild(containerRef.current?.childNodes[0]);
+            }
+            containerRef.current?.appendChild(renderer.domElement);
+        } else if (containerRef.current && !containerRef.current.childNodes.length) {
+            containerRef.current?.appendChild(renderer.domElement);
+        }
+        const animate = () => {
+            if (grass) {
+                grass.refresh();
+            }
+            controls.update();
+            renderer.render(scene, camera);
+            animationID = requestAnimationFrame(animate);
+        };
+
+        cancelAnimation();
+        animate();
+
+        // Clean up the event listener when the component is unmounted
+        return () => {};
+    }, [camera, controls, renderer, scene]);
+
+    useEffect(()=>{
+        setInitialCameraPosition(
+            camera,
+            renderer,
+            controls,
+            scene,
+            width,
+            height,
+            threeControl,
+            selected);
+    }, [camera, renderer, controls, threeControl])
 
     const addArrowHelper = ()=>{
         const arrowGroup = getArrowHelper();
 
         scene.add(arrowGroup);
-
-        if (process.env.NODE_ENV === "development") {
-            window.AT_Editor = window.AT_Editor || {};
-            window.AT_Editor.arrows = arrowGroup;
-        }
     }
 
     const updateArrowHelper = ()=>{
         if (scene && scene.children && selected) {
             if (!arrowHelpers) {
                 addArrowHelper();
-                arrowHelpers = scene.children.find(mesh => mesh instanceof THREE.Group &&
+                arrowHelpers = scene.children.find((mesh: Object3D) => mesh instanceof THREE.Group &&
                     mesh.name === "arrows") as THREE.Group
             }
             if (arrowHelpers) {
@@ -251,7 +287,7 @@ export default function ThreeComponent({
 
             const rayCaster = new THREE.Raycaster();
             rayCaster.setFromCamera(mouse, camera);
-            return rayCaster.intersectObjects(scene.children.filter(mesh =>
+            return rayCaster.intersectObjects(scene.children.filter((mesh: Object3D) =>
                 mesh.name.startsWith("mesh") || mesh.name === "plane"), true);
         }
         return [];
@@ -305,81 +341,31 @@ export default function ThreeComponent({
                             radius: (shadowObject.geometry as THREE.SphereGeometry).parameters.radius
                         }]);
                 }
-                scene.remove(shadowObject);
-                shadowObject = null;
+
+                shadowObject.position.z = -100;
+
             }
         }
-
     };
-
-    const addBasePlane = async () => {
-        if (!scene || scene.children.find(mesh => mesh.name === "plane")) {
-            return false;
-        }
-        const plane = await getGroundPlane(planeSize, planeSize, ground);
-        scene.add(plane);
-        return plane;
-    };
-
-    const setEnvironment = () => {
-        if (grassEnabled) {
-            if (grass && !grass.getFromScene()) {
-                grass.addToScene();
-            } else if (!grass) {
-                grass = new Grass(scene,{
-                    instances: 1000000,
-                    width: planeSize,
-                    height: planeSize
-                });
-                grass.addToScene();
-            } else {
-                grass.setDimensions(planeSize, planeSize)
-            }
-        }
-        if (skyEnabled) {
-            renderEnvironment(scene);
-        }
-    }
 
     if (scene) {
         arrowHelpers =
-            scene.children.find(mesh => mesh instanceof THREE.Group &&
+            scene.children.find((mesh: Object3D) => mesh instanceof THREE.Group &&
                 mesh.name === "arrows") as THREE.Group;
 
-        scene.children.forEach((mesh) => {
+        scene.children.forEach((mesh: Object3D) => {
             if (helperNames.includes(mesh.name)) {
                 helpersCount++;
             }
         });
     }
 
-    if (shadowObject) {
-        helpersCount++;
-        const inScene = scene.children.find(mesh=>mesh.name === "shadowObject");
-        if (!inScene) {
-            scene.add(shadowObject);
-        }
-    }
-    useEffect(loadTHREEComponent, [height, width]);
-
-    if (scene && scene.children.length - helpersCount < items.length) {
-        refreshSceneItems();
-        void addBasePlane().then(() => setEnvironment())
-    }
-
-    if (loaded && camera && renderer && camera.aspect !== width / height) {
+    if (camera && renderer && camera.aspect !== width / height) {
         camera.aspect = width / height;
         if (grass) {
             grass.setDimensions(planeSize, planeSize);
         }
         updateCameraPosition();
-    } else if (controls && threeControl) {
-        if ((threeControl === "trackball" && controls instanceof OrbitControls) ||
-            (threeControl === "orbit" && controls instanceof TrackballControls) ||
-            (threeControl === "object" && controls instanceof TrackballControls)) {
-            updateControls();
-            updateCameraPosition();
-        }
     }
     updateArrowHelper();
 
@@ -395,7 +381,6 @@ export default function ThreeComponent({
         if (reference.type === "cursor") {
             return;
         }
-        const justCreated = !shadowObject;
         const intersects = getMouseIntersects(event);
 
         if (intersects.length) {
@@ -405,31 +390,12 @@ export default function ThreeComponent({
             if (intersect) {
                 const point = intersect.point;
                 const mainObject = intersect.object as Mesh;
-                if (justCreated) {
-                    const config = {
-                        ...reference,
-                        color: "#3cffee",
-                    };
-                    switch (reference.type) {
-                        case "rect":
-                            (config as Rectangle).w = 50;
-                            (config as Rectangle).h = 50;
-                            break;
-                        case "circle":
-                            (config as Circle).radius = 25;
-                            break;
-                    }
-                    shadowObject = getMeshForItem(config);
-                    shadowObject.name = "shadowObject";
-                    (shadowObject.material as THREE.MeshBasicMaterial).opacity = 0.5;
-                    (shadowObject.material as THREE.MeshBasicMaterial).needsUpdate = true;
-                }
-
                 if (shadowObject) {
                     const movementSpeed = 3; // Adjust the speed as needed
                     shadowObject.position.copy(camera.position)
                     const direction = point.clone().sub(shadowObject.position);
                     direction.normalize();
+
 
                     const directionVector = direction.multiplyScalar(movementSpeed);
                     let i = 0;
@@ -440,10 +406,6 @@ export default function ThreeComponent({
                             break;
                         }
                     }
-
-                    if (justCreated) {
-                        scene.add(shadowObject);
-                    }
                 }
             }
         }
@@ -452,8 +414,7 @@ export default function ThreeComponent({
     const onMouseOut = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
         event.preventDefault();
         if (shadowObject) {
-            scene.remove(shadowObject);
-            shadowObject = null;
+            shadowObject.position.z = -100;
         }
     };
 

--- a/components/lib/ThreeComponent.tsx
+++ b/components/lib/ThreeComponent.tsx
@@ -17,6 +17,7 @@ import {
     setInitialCameraPosition
 } from "@/src/utils/model";
 import { Object3D } from "three/src/core/Object3D";
+import {useWindow} from "@/src/utils/react";
 
 let animationID: number|undefined;
 
@@ -131,14 +132,21 @@ export default function ThreeComponent({
         renderer,
         scene,
         grass
-    } = useMemo(initializeThreeGlobals, []);
+    } = useWindow(initializeThreeGlobals, [
+        "camera",
+        "renderer",
+        "scene",
+        "grass"
+    ]);
 
-    const controls: TrackballControls | OrbitControls = useMemo(() => {
-        window.AT_Editor = window.AT_Editor || {};
-        window.AT_Editor.controls = window.AT_Editor.controls ||
-            getControls(threeControl, camera, renderer);
-        return window.AT_Editor.controls;
-    }, [threeControl, camera, renderer]);
+    const controls: TrackballControls | OrbitControls =
+        useWindow(function (this: TrackballControls | OrbitControls | undefined) {
+            if (this) {
+                this?.dispose();
+            }
+            return getControls(threeControl, camera, renderer);
+        },
+        "controls", threeControl);
 
     const shadowObject: Mesh|null|undefined = scene.children.find((mesh: Object3D)=>
         mesh.name === "shadowObject") as Mesh|undefined;

--- a/src/types/react.ts
+++ b/src/types/react.ts
@@ -1,0 +1,5 @@
+export interface AnyObj {
+    [key: string]: any
+}
+
+export type WindowMethod = () => any;

--- a/src/utils/draw.ts
+++ b/src/utils/draw.ts
@@ -4,7 +4,7 @@ import {getContrastToHEX, interpolateColor} from "@/src/utils/general";
 import {degToRad} from "@/src/utils/math";
 
 export class Draw implements DrawInterface{
-    private context?: CanvasRenderingContext2D;
+    private context?: CanvasRenderingContext2D | null;
     private readonly canvas: HTMLCanvasElement;
 
     private backgroundColor: string;
@@ -17,6 +17,7 @@ export class Draw implements DrawInterface{
     constructor(canvas: HTMLCanvasElement, options?: DrawOptions) {
         const opt = options || {};
         this.canvas = canvas;
+        this.context = this.canvas.getContext('2d');
         if (opt.background) {
             this.background = new Image();
             this.background.src = opt.background;
@@ -63,10 +64,10 @@ export class Draw implements DrawInterface{
 
     updateCanvas() {
         if (this.canvas) {
-            const ctx = this.canvas.getContext('2d');
-            if (ctx) {
-                this.context = ctx;
+            if(!this.context) {
+                this.context = this.canvas.getContext('2d');
             }
+            const ctx = this.context;
             if (this.context) {
                 if (this.background) {
                     const pattern = this.context.createPattern(this.background, 'repeat');

--- a/src/utils/grass/grass.ts
+++ b/src/utils/grass/grass.ts
@@ -40,7 +40,6 @@ export class Grass {
     }
 
     regenerateGrassCoordinates() {
-        console.log('Regen grass ', this.width, this.height, !!this.instancedMesh);
         if (!this.instancedMesh) {
             return false;
         }

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -1,12 +1,14 @@
 import {GLTF, GLTFLoader} from "three/examples/jsm/loaders/GLTFLoader";
 import {
-    BufferGeometry,
+    ArrowHelper,
+    BoxGeometry,
+    BufferGeometry, Color, CylinderGeometry,
     Group,
-    Mesh,
+    Mesh, MeshBasicMaterial,
     MeshPhongMaterial,
     NormalBufferAttributes,
     Object3DEventMap,
-    PerspectiveCamera
+    PerspectiveCamera, Quaternion, SphereGeometry, Vector3
 } from "three";
 import {FBXLoader} from "three/examples/jsm/loaders/FBXLoader";
 import {OBJLoader} from "three/examples/jsm/loaders/OBJLoader";
@@ -15,6 +17,7 @@ import {ColladaLoader} from "three/examples/jsm/loaders/ColladaLoader";
 import {STLLoader} from "three/examples/jsm/loaders/STLLoader";
 import * as THREE from "three";
 import {Object3D} from "three/src/core/Object3D";
+import {AssetObject, Circle, Line, Rectangle} from "@/src/types/assets";
 
 const genericLoader = (file: File, modelLoader: Loader) => {
     return new Promise(resolve => {
@@ -81,4 +84,87 @@ export const lookAtObject = (models: Object3D, camera: PerspectiveCamera): void 
     cameraPosition.z += boundingBoxDistance;
     camera.position.copy(cameraPosition);
     camera.lookAt(boundingBoxCenter);
+}
+
+export const getMeshForItem = (item: AssetObject): THREE.Mesh => {
+    let model;
+    let material = new MeshBasicMaterial({ color: item.color ?
+            new Color(item.color) : 0x000000 });
+    let geometry;
+    let position1, position2;
+    switch (item.type) {
+        case "rect":
+            const rect = item as Rectangle;
+            geometry = new BoxGeometry(rect.w, rect.h, Math.round((rect.w + rect.h) / 2));
+            break;
+        case "circle":
+            geometry = new SphereGeometry((item as Circle).radius, 32, 16 );
+            break;
+        case "line":
+            const line = item as Line;
+            position1 = new Vector3(line.x1, line.y1, 0);
+            position2 = new Vector3(line.x2, line.y2, 0);
+            const height = position1.distanceTo(position2);
+
+            geometry = new CylinderGeometry( 5, 5, height, 32 );
+    }
+    model = new Mesh(geometry, material);
+    if (model && position1 && position2) {
+        const positionMid = new Vector3();
+        positionMid.addVectors(position1, position2).multiplyScalar(0.5);
+        model.position.copy(positionMid);
+        const direction = new Vector3();
+        direction.subVectors(position2, position1).normalize();
+
+        const quaternion = new Quaternion();
+        quaternion.setFromUnitVectors(new Vector3(0, 1, 0), direction);
+        model.setRotationFromQuaternion(quaternion);
+    } else if (model && item.type === "rect") {
+        const rect = item as Rectangle;
+        model.position.set(rect.x + rect.w / 2, rect.y + rect.h / 2, rect.z || 0);
+    } else if (model && typeof item.x === 'number' && typeof item.y === "number") {
+        model.position.set(item.x, item.y, item.z || 0);
+    }
+    return model;
+};
+
+export const getArrowHelper = (): Group => {
+    const arrowGroup = new Group();
+    arrowGroup.name = "arrows";
+    const xAxisDirection = new Vector3(1, 0, 0);
+    const yAxisDirection = new Vector3(0, 1, 0);
+    const zAxisDirection = new Vector3(0, 0, 1);
+
+    const origin = new Vector3( 0, 0, 0 );
+    const length = 100;
+
+    const xAxisArrow = new ArrowHelper(xAxisDirection, origin, length, 0xff0000);
+    const yAxisArrow = new ArrowHelper(yAxisDirection, origin, length, 0x00ff00);
+    const zAxisArrow = new ArrowHelper(zAxisDirection, origin, length, 0x0000ff);
+
+    arrowGroup.add(xAxisArrow);
+    arrowGroup.add(yAxisArrow);
+    arrowGroup.add(zAxisArrow);
+
+    return arrowGroup;
+}
+
+export const getGroundPlane = (width: number, height: number, texture?:string): Promise<Mesh<THREE.PlaneGeometry, MeshBasicMaterial, Object3DEventMap>> => {
+    return new Promise(resolve => {
+        const geometry = new THREE.PlaneGeometry(width, height);
+        const material = new THREE.MeshBasicMaterial( {color: 0xffff00, side: THREE.DoubleSide} );
+        const loader = new THREE.TextureLoader();
+        loader.load(texture || '/assets/textures/green-grass-textures.jpg',
+            function ( texture ) {
+                texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
+                texture.offset.set( 0, 0 );
+                texture.repeat.set( 2, 2 );
+                material.map = texture;
+                material.needsUpdate = true;
+                const plane = new THREE.Mesh( geometry, material );
+                plane.position.setZ(-1);
+                plane.name = "plane";
+                resolve(plane);
+            });
+    });
 }

--- a/src/utils/react.ts
+++ b/src/utils/react.ts
@@ -1,0 +1,48 @@
+/**
+ * React Overrides/Replacement methods
+ */
+import {AnyObj, WindowMethod} from "@/src/types/react";
+
+
+export const useWindow = (method: WindowMethod, id: string|object, ref?: any) => {
+    window.AT_Editor = window.AT_Editor || {};
+    window.AT_Editor.windowCache = window.AT_Editor.windowCache || {};
+    window.AT_Editor.windowRefs = window.AT_Editor.windowRefs || {};
+
+    if (typeof id === "object") {
+        const keys = Array.isArray(id) ? id : Object.keys(id);
+        let missing = false;
+        const output = keys.reduce((out, key) => {
+            if (window.AT_Editor.windowCache[key] &&
+                (ref === undefined || window.AT_Editor.windowRefs[key] === ref)) {
+                out[key] = window.AT_Editor.windowCache[key]
+            } else {
+                missing = true;
+            }
+            return out;
+        }, {} as AnyObj);
+
+        if (!missing) {
+            console.log('Return cached data');
+            return output;
+        }
+        const result = method.call(output);
+
+        return keys.reduce((out, key) => {
+            if (result[key]) {
+                window.AT_Editor.windowCache[key] = result[key];
+                window.AT_Editor.windowRefs[key] = ref;
+                out[key] = result[key]
+            }
+            return out;
+        }, {} as AnyObj);
+    }
+    if (window.AT_Editor.windowCache[id] &&
+        (ref === undefined || window.AT_Editor.windowRefs[id] === ref)) {
+        console.log("Return cached id data");
+        return window.AT_Editor.windowCache[id];
+    }
+    window.AT_Editor.windowRefs[id] = ref;
+    window.AT_Editor.windowCache[id] = method.call(window.AT_Editor.windowCache[id]);
+    return window.AT_Editor.windowCache[id];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
     "paths": {
       "@/*": ["./*"]
     },
-    "types": ["./src/types/imports.d.ts", ".next/types/imports.d.ts"]
+    "types": ["./src/types/imports.d.ts"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
I had issues with NextJS [Fast Refresh] rebuilding, because on every render iteration a new CanvasContext was created.

Every THREE.js related object were affected so, it needed a refactor to keep THREE globals in place over re-renders.

Since useMemo was sufficient to safely store scene, camera, render and control references, I created a useWindow method to handle all with keeping the React syntax.